### PR TITLE
feat(web): apiFetch ラッパ導入 & BFF /api/whoami 実装（JWT 透過・no-store）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+.github/*

--- a/src/app/api/whoami/route.ts
+++ b/src/app/api/whoami/route.ts
@@ -1,0 +1,59 @@
+// src/app/api/whoami/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { apiFetch } from '@/lib/api-fetch';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type MeResponse = {
+  user: { id: number; name: string; email: string };
+};
+
+// --- ベースURL解決: 環境変数 > Docker想定 > ローカル ---
+function resolveApiBase(): string {
+  const fromEnv =
+    process.env.API_BASE_URL ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    '';
+
+  if (fromEnv.trim()) return fromEnv;
+
+  // コンテナ内かどうかの簡易判定（必要なら docker-compose に IN_DOCKER=1 を追加）
+  const inDocker =
+    process.env.IN_DOCKER === '1' ||
+    process.env.DOCKER === '1' ||
+    process.env.CONTAINER === 'true';
+
+  return inDocker ? 'http://api:3000' : 'http://localhost:3001';
+}
+
+const API_BASE = resolveApiBase();
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get('authorization') ?? '';
+
+  try {
+    const result = await apiFetch<MeResponse>(`${API_BASE}/me`, {
+      headers: auth ? { Authorization: auth } : {},
+      cache: 'no-store',
+    });
+
+    if (result.ok) {
+      return NextResponse.json(result.data, { status: result.status });
+    }
+
+    // BFFはAPIのステータスをそのまま返す
+    return NextResponse.json(result.error, { status: result.status });
+  } catch (e) {
+    const message =
+      e instanceof Error ? `${e.name}: ${e.message}` : 'Unknown error';
+
+    // ログ（必要なら base も出す）
+    console.error('[BFF /api/whoami] fetch error:', message, 'API_BASE=', API_BASE);
+
+    return NextResponse.json(
+      { message: 'BFF failed to fetch /me', details: message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,9 @@
+// src/app/dashboard/page.tsx
+export default function DashboardPage() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>ここに /api/me の結果などを表示予定</p>
+    </div>
+  )
+}

--- a/src/lib/api-fetch.ts
+++ b/src/lib/api-fetch.ts
@@ -1,0 +1,135 @@
+// src/lib/api-fetch.ts
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface ApiFetchOptions<B = unknown> {
+  method?: HttpMethod;
+  headers?: Record<string, string>;
+  body?: B;
+  cache?: RequestCache;
+  credentials?: RequestCredentials;
+  next?: NextFetchRequestConfig;
+  baseUrl?: string; // ★ baseUrl を追加
+}
+
+export interface ApiSuccess<T> {
+  ok: true;
+  status: number;
+  data: T;
+  headers: Headers;
+  token?: string;
+}
+
+export interface ApiFail {
+  ok: false;
+  status: number;
+  error: {
+    message: string;
+    code?: string;
+    details?: unknown;
+  };
+  headers: Headers;
+}
+
+export type ApiResult<T> = ApiSuccess<T> | ApiFail;
+
+// ---- ユーティリティ ----
+function readJwtFromHeaders(headers: Headers): string | undefined {
+  const auth = headers.get('authorization');
+  if (!auth) return undefined;
+  const prefix = 'Bearer ';
+  return auth.startsWith(prefix) ? auth.slice(prefix.length) : undefined;
+}
+
+function safeJsonParse(text: string): unknown {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function toErrorMessage(payload: unknown): string {
+  if (typeof payload === 'string') return payload;
+
+  if (payload && typeof payload === 'object') {
+    const obj = payload as Record<string, unknown>;
+    if (typeof obj.message === 'string') return obj.message;
+
+    if (Array.isArray(obj.errors)) {
+      const arr = obj.errors as unknown[];
+      const texts = arr.map((e) => (typeof e === 'string' ? e : '')).filter(Boolean);
+      if (texts.length) return texts.join(', ');
+    }
+
+    if (typeof obj.error === 'string') return obj.error;
+  }
+
+  return 'Request failed';
+}
+
+// ---- 本体 ----
+export async function apiFetch<T, B = unknown>(
+  path: string,
+  options: ApiFetchOptions<B> = {},
+): Promise<ApiResult<T>> {
+  const {
+    method = 'GET',
+    headers: userHeaders,
+    body,
+    cache = 'no-store',
+    credentials,
+    next,
+    baseUrl,
+  } = options;
+
+  const headers = new Headers(userHeaders ?? {});
+  const init: RequestInit & { next?: NextFetchRequestConfig } = {
+    method,
+    headers,
+    cache,
+    credentials,
+    next,
+  };
+
+  if (body !== undefined) {
+    const isFormData = typeof FormData !== 'undefined' && body instanceof FormData;
+    if (isFormData) {
+      init.body = body as unknown as BodyInit;
+      headers.delete('Content-Type');
+    } else {
+      headers.set('Content-Type', 'application/json');
+      init.body = JSON.stringify(body);
+    }
+  }
+
+  // ★ baseUrl があれば組み立てる
+  const url = baseUrl ? new URL(path, baseUrl).toString() : path;
+
+  const res = await fetch(url, init);
+  const token = readJwtFromHeaders(res.headers);
+
+  const text = await res.text();
+  const json = safeJsonParse(text);
+
+  if (res.ok) {
+    return {
+      ok: true,
+      status: res.status,
+      data: json as T,
+      headers: res.headers,
+      token,
+    };
+  }
+
+  return {
+    ok: false,
+    status: res.status,
+    error: {
+      message: toErrorMessage(json),
+      details: json,
+    },
+    headers: res.headers,
+  };
+}

--- a/src/lib/auth-token.ts
+++ b/src/lib/auth-token.ts
@@ -1,0 +1,14 @@
+import { cookies } from 'next/headers';
+
+/** サーバ側で cookie から token を取得（App Router） */
+export async function getServerToken(): Promise<string | null> {
+  // cookies() は Promise なので await 必須
+  const cookieStore = await cookies();
+  return cookieStore.get('auth_token')?.value ?? null;
+}
+/** クライアント側で cookie から token を取得（必要なら） */
+export function getClientToken(cookieName = 'auth_token'): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const m = document.cookie.match(new RegExp(`(?:^|; )${cookieName}=([^;]*)`));
+  return m ? decodeURIComponent(m[1]) : undefined;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,7 @@
+/**
+ * API のベースURLを一元管理。
+ * - BFF経由にするなら '/api' 固定
+ * - 直接 Rails API を叩くなら NEXT_PUBLIC_API_BASE をセット
+ */
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE?.replace(/\/+$/, '') || '/api';

--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -1,0 +1,35 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
+
+export type ApiResult<T> = {
+  ok: true;
+  data: T;
+  status: number;
+  headers: Headers;
+} | {
+  ok: false;
+  error: ApiError;
+  status: number;
+  headers: Headers;
+};
+
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+  details?: unknown;
+
+  constructor(message: string, status: number, code?: string, details?: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}


### PR DESCRIPTION
## 概要
- 共通 API クライアント `apiFetch` を追加（型安全な戻り値・エラー整形・JWT ヘッダ読取・既定 no-store）
- BFF `/api/whoami` を実装。クライアント → BFF → Rails `/me` で JWT 認証を透過
- 認証なしは 401 をそのまま返却（フロントがリダイレクト等制御可能）
- docker-compose: web の environment を mapping 化（型通りに注入）

## 動作確認
- サインアップ: `POST /users` → `user + token` を JSON 返却
- サインイン: `POST /users/sign_in` → 同様に `user + token`
- `/me`:
  - `Authorization: Bearer <token>` あり → 200 で `user`
  - なし → 401 Unauthorized
- `/api/whoami`（BFF）:
  - あり → 200 / なし → 401
- `apiFetch` の `cache: 'no-store'` により連続アクセスで毎回サーバログに出力

## 影響範囲
- 認証系 BFF 実装の土台
- 以降の保護ルート/ログインフローの共通依存

## 次ステップ
- /login /signup 画面（暫定UI）
- ログイン時の JWT 保持（HttpOnly Cookie もしくは Memory + BFF）方針決定
- /dashboard の保護（middleware で 401→/login）
