### PR TITLE
[WEB] [M1] BFFルート追加（/api/session・/api/auth/refresh）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 
 .github/*
+jar.txt

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,18 +2,19 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
-/** ---- 設定 ---- */
+/** ==== 設定 ==== */
 const AUTH_COOKIE_NAME = "auth_token"
 
-// 末尾（last segment）が一致するパスを保護
-const PROTECTED_LAST_SEGMENTS = new Set(["dashboard"])
+// ロケールを除いた「ベースパス」で startsWith 判定する保護パス
+const PROTECTED_PREFIXES = ["/dashboard"]
 
-// 公開パスの先頭プレフィックス（ミドルウェア対象外）
-//   - /api, /_next, 静的拡張子, メタ系は matcher 側で除外しているため、ここではUI系の明示を中心に。
-//   - /login は公開扱い。ただし「ログイン済みなら /dashboard へ」というUI制御はこの中では行わない（下の isLoginPath で個別対応）
+// UI公開パスの先頭プレフィックス
 const PUBLIC_PREFIXES: readonly string[] = ["/signup", "/logout"]
 
-/** ---- ユーティリティ ---- */
+// サポートするロケール（必要に応じて追加）
+const LOCALES = new Set(["ja", "en", "en-US"])
+
+/** ==== ユーティリティ ==== */
 function splitPath(pathname: string) {
   return pathname.split("/").filter(Boolean)
 }
@@ -31,32 +32,40 @@ function isLoginPath(pathname: string): boolean {
   return getLastSegment(pathname) === "login"
 }
 
-// /dashboard, /ja/dashboard など「末尾が dashboard」を保護対象とみなす
+// /ja/foo → { locale:'ja', base:'/foo' } という形に分解
+function splitLocaleBase(pathname: string): { locale: string | null; base: string } {
+  const segs = splitPath(pathname)
+  const maybeLocale = segs[0]
+  if (maybeLocale && LOCALES.has(maybeLocale)) {
+    const rest = "/" + segs.slice(1).join("/")
+    return { locale: maybeLocale, base: rest || "/" }
+  }
+  return { locale: null, base: pathname || "/" }
+}
+
+// /dashboard, /ja/dashboard などを保護対象とみなす（ベースで判定）
 function isProtectedPath(pathname: string): boolean {
-  return PROTECTED_LAST_SEGMENTS.has(getLastSegment(pathname))
+  const { base } = splitLocaleBase(pathname)
+  return PROTECTED_PREFIXES.some((p) => base === p || base.startsWith(`${p}/`))
 }
 
 // UI公開プレフィックス判定（/signup, /logout など）
 function isPublicPath(pathname: string): boolean {
-  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+  const { base } = splitLocaleBase(pathname)
+  return PUBLIC_PREFIXES.some((p) => base === p || base.startsWith(`${p}/`))
 }
 
-// ロケール（最初のセグメントが言語っぽい時に採用したい場合はここを拡張）
-// ここでは「存在していればそれを維持」するだけで、i18nの付与は行わない
+// ロケール（先頭セグメントがサポート言語のときだけ採用）
 function extractLeadingLocale(pathname: string): string | null {
   const head = getFirstSegment(pathname)
-  // 必要に応じてサポート言語配列で厳密判定: const LOCALES = ['ja','en'] as const
-  // 例）return LOCALES.includes(head as any) ? head! : null
-  // ここでは「何か最初のセグメントがあればロケールかも」として維持目的で返す
-  return head ?? null
+  return head && LOCALES.has(head) ? head : null
 }
 
-// ロケールを保ったまま、ベースパス（login/dashboard など）に差し替える
+// ロケールを保ったまま、ベース（login/dashboard など）に差し替える
 function buildLocalizedPath(pathname: string, targetBase: string): string {
   const locale = extractLeadingLocale(pathname)
   if (!locale) return `/${targetBase}`
   const segs = splitPath(pathname)
-  // 既存の最初のセグメントをロケールと仮定し、/<locale>/<targetBase> に寄せる
   segs.splice(1) // ロケール以外を捨てる
   return `/${locale}/${targetBase}`
 }
@@ -78,13 +87,12 @@ function redirectToLogin(req: NextRequest, reason?: string): NextResponse {
   return NextResponse.redirect(url)
 }
 
-/** ---- ミドルウェア本体 ---- */
+/** ==== ミドルウェア本体 ==== */
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl
   const hasAuth = Boolean(req.cookies.get(AUTH_COOKIE_NAME)?.value)
 
   // 1) 公開パス（UIのみ）: 基本スルー
-  //    ※ /api, /_next, 静的やメタは config.matcher で除外しているのでここでは見ない
   if (isPublicPath(pathname)) return NextResponse.next()
 
   // 2) ログイン画面: ログイン済みなら /dashboard に寄せる
@@ -98,9 +106,7 @@ export async function middleware(req: NextRequest) {
       return redirectToLogin(req, "unauthorized")
     }
 
-    // ---- オプション: 厳密検証（/api/me でサーバ検証） ----
-    //   Edge Runtime での外部 fetch は可能ですが、レスポンスを信頼できる同一サイトの検証に限定してください。
-    //   署名検証はRails側（/api/meなど）で行う前提。
+    // ---- 厳密検証（/api/me でサーバ検証） ----
     if (process.env.NEXT_ENABLE_STRICT_AUTH === "1") {
       try {
         const origin = req.nextUrl.origin
@@ -119,13 +125,7 @@ export async function middleware(req: NextRequest) {
   return NextResponse.next()
 }
 
-/** ---- matcher（ミドルウェア適用範囲）----
- * Next.js推奨の「負マッチ」スタイルで以下を除外:
- * - /api（Route Handler）
- * - /_next（静的/内部）
- * - 静的拡張子（.png/.jpg/...）
- * - メタファイル（favicon/sitemap/robots）
- */
+/** ==== matcher（ミドルウェア適用範囲）==== */
 export const config = {
   matcher: [
     "/((?!api|_next|favicon.ico|sitemap.xml|robots.txt|.*\\.(png|jpg|jpeg|gif|svg|webp|ico|txt|xml)$).*)",

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -61,13 +61,14 @@ export default function LoginPage() {
   const handleDemoLogin = async () => {
     // デモ用資格情報（必要に応じて変更）
     const demoEmail = 'demo@example.com'
-    const demoPassword = 'demo123'
+    const demoPassword = 'password'
     setFormData({ email: demoEmail, password: demoPassword })
     setError('')
     setIsLoading(true)
     try {
       await doLogin(demoEmail, demoPassword)
       router.push('/dashboard')
+      router.refresh()
     } catch (err: unknown) {
       setError(getErrorMessage(err))
     } finally {
@@ -114,7 +115,7 @@ export default function LoginPage() {
                 )}
               </Button>
               <p className="text-xs text-white/50 text-center mt-2">
-                メール: demo@example.com / パスワード: demo123
+                メール: demo@example.com / パスワード: password
               </p>
             </div>
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,22 +1,10 @@
 // src/app/api/auth/login/route.ts
+// cspell:ignore globy
 import { NextResponse, type NextRequest } from "next/server"
-import {
-  resolveApiBase,
-  setAuthCookies,
-  clearAuthCookiesOn,
-} from "../../_auth-helpers"
+import { resolveApiBase, clearAuthCookiesOn } from "../../_auth-helpers" // setAuthCookies はもう使わない
 
-type LoginBody = {
-  email: string
-  password: string
-}
-
-type RailsUser = {
-  id: number | string
-  name?: string | null
-  email: string
-}
-
+type LoginBody = { email: string; password: string }
+type RailsUser = { id: number | string; name?: string | null; email: string }
 type RailsSignInResponse = {
   user?: RailsUser | null
   token?: string
@@ -35,74 +23,176 @@ function pickLoginBody(u: unknown): LoginBody | null {
   if (!isObject(u)) return null
   const email = u["email"]
   const password = u["password"]
-  if (typeof email === "string" && typeof password === "string") {
-    return { email, password }
-  }
+  if (typeof email === "string" && typeof password === "string") return { email, password }
   return null
 }
 
+/** クロス環境で使えるミリ秒タイマー */
+const nowMs = () =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now()
+
+/** Server-Timing 用の文字列を安全に連結 */
+function appendServerTiming(
+  res: NextResponse,
+  metrics: Array<{ name: string; dur?: number; desc?: string }>,
+) {
+  const prev = res.headers.get("Server-Timing")
+  const add = metrics
+    .filter(Boolean)
+    .map((m) => {
+      const parts = [m.name]
+      if (typeof m.dur === "number" && !Number.isNaN(m.dur)) {
+        parts.push(`dur=${Math.max(0, Math.round(m.dur))}`)
+      }
+      if (m.desc) {
+        const safe = m.desc.replace(/"/g, "'")
+        parts.push(`desc="${safe}"`)
+      }
+      return parts.join(";")
+    })
+    .join(", ")
+  res.headers.set("Server-Timing", prev ? `${prev}, ${add}` : add)
+}
+
+// ===================== COOKIE_FWD_START:multi_set_cookie =====================
+/** Undici の getSetCookie() があれば使い、無ければ単一 set-cookie を配列化して返す */
+function getSetCookieList(from: Response): string[] {
+  const h = from.headers as unknown as { getSetCookie?: () => string[] }
+  if (typeof h.getSetCookie === "function") {
+    try {
+      const list = h.getSetCookie()
+      return Array.isArray(list) ? list : []
+    } catch {
+      // フォールバックへ
+    }
+  }
+  const single = from.headers.get("set-cookie")
+  return single ? [single] : []
+}
+
+/** Railsからの複数 Set-Cookie をそのまま前方転送（append） */
+function forwardSetCookies(from: Response, to: NextResponse): void {
+  for (const v of getSetCookieList(from)) {
+    to.headers.append("set-cookie", v)
+  }
+}
+// ===================== COOKIE_FWD_END:multi_set_cookie =====================
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
 export async function POST(req: NextRequest) {
+  const t0 = nowMs()
+
   const raw = (await req.json().catch(() => null)) as unknown
   const body = pickLoginBody(raw)
-
   if (!body) {
-    return NextResponse.json(
-      { ok: false, message: "メール/パスワードが未入力です" },
-      { status: 400 },
-    )
+    const res = NextResponse.json({ ok: false, message: "メール/パスワードが未入力です" }, { status: 400 })
+    appendServerTiming(res, [{ name: "total", dur: nowMs() - t0, desc: "Total handler time" }])
+    return res
   }
+
+  let railsMs = 0
+  const reqId = crypto.randomUUID()
 
   try {
     const apiBase = resolveApiBase()
-    const r = await fetch(`${apiBase}/users/sign_in`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      cache: "no-store",
-      body: JSON.stringify({ user: body }),
-    })
 
-    const data =
-      ((await r.json().catch(() => ({}))) as Partial<RailsSignInResponse>) ?? {}
+    const tFetch0 = nowMs()
+    // ===================== LOGIN_SWITCH_START:/auth/login =====================
+    // Deviseの /users/sign_in ではなく、JWT発行の /auth/login を叩く
+    const r = await fetch(`${apiBase}/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Request-ID": reqId, // Rails ログ突合用
+        "X-BFF": "globy-web",
+      },
+      cache: "no-store",
+      // Rails 側は params[:email], params[:password] を想定
+      body: JSON.stringify({ email: body.email, password: body.password }),
+    })
+    // ===================== LOGIN_SWITCH_END:/auth/login =====================
+    railsMs = nowMs() - tFetch0
+
+    const data = ((await r.json().catch(() => ({}))) as Partial<RailsSignInResponse>) ?? {}
 
     if (!r.ok) {
       const res = NextResponse.json(
-        {
-          ok: false,
-          code: data.code,
-          message: data.detail || "ログインに失敗しました",
-        },
+        { ok: false, code: data.code, message: data.detail || "ログインに失敗しました" },
         { status: r.status },
       )
       clearAuthCookiesOn(res)
+      // 計測ヘッダ
+      appendServerTiming(res, [
+        { name: "rails_login", dur: railsMs, desc: "/auth/login" },
+        { name: "total", dur: nowMs() - t0, desc: "Total handler time" },
+      ])
+      res.headers.set("X-Proxy-Request-ID", reqId)
+      res.headers.set("X-Login-Timing-Rails-Login", String(Math.round(railsMs)))
+      res.headers.set("X-Login-Timing-Total", String(Math.round(nowMs() - t0)))
+
+      console.log(
+        JSON.stringify({
+          tag: "api/auth/login",
+          ok: false,
+          status: r.status,
+          rails_login_ms: Math.round(railsMs),
+          total_ms: Math.round(nowMs() - t0),
+          reqId,
+        }),
+      )
       return res
     }
 
-    const accessToken = data.access_token ?? data.token
-    const refreshToken = data.refresh_token
-    const atMaxAgeSec = Number(data.at_expires_in) || 900 // 15分
-    const rtMaxAgeSec = Number(data.rt_expires_in) || 60 * 60 * 24 * 30 // 30日
+    // BFFはCookieを自前で作らず、RailsのSet-Cookieを前方転送する
+    const res = NextResponse.json({ ok: true, user: data.user ?? null }, { status: 200 })
+    // ===================== COOKIE_FWD_START:multi_set_cookie =====================
+    forwardSetCookies(r, res)
+    // ===================== COOKIE_FWD_END:multi_set_cookie =====================
 
-    const res = NextResponse.json(
-      { ok: true, user: data.user ?? null },
-      { status: 200 },
+    appendServerTiming(res, [
+      { name: "rails_login", dur: railsMs, desc: "/auth/login" },
+      { name: "total", dur: nowMs() - t0, desc: "Total handler time" },
+    ])
+    res.headers.set("X-Proxy-Request-ID", reqId)
+    res.headers.set("X-Login-Timing-Rails-Login", String(Math.round(railsMs)))
+    res.headers.set("X-Login-Timing-Total", String(Math.round(nowMs() - t0)))
+
+    console.log(
+      JSON.stringify({
+        tag: "api/auth/login",
+        ok: true,
+        rails_login_ms: Math.round(railsMs),
+        total_ms: Math.round(nowMs() - t0),
+        reqId,
+      }),
     )
-
-    if (accessToken) {
-      setAuthCookies(res, {
-        accessToken,
-        refreshToken,
-        atMaxAgeSec,
-        rtMaxAgeSec,
-      })
-    }
 
     return res
-  } catch {
-    const res = NextResponse.json(
-      { ok: false, message: "サーバに接続できませんでした" },
-      { status: 502 },
-    )
+  } catch (e) {
+    const res = NextResponse.json({ ok: false, message: "サーバに接続できませんでした" }, { status: 502 })
     clearAuthCookiesOn(res)
+    appendServerTiming(res, [
+      { name: "rails_login", dur: railsMs, desc: "/auth/login (partial)" },
+      { name: "total", dur: nowMs() - t0, desc: "Total handler time" },
+    ])
+    res.headers.set("X-Proxy-Request-ID", reqId)
+    res.headers.set("X-Login-Timing-Rails-Login", String(Math.round(railsMs)))
+    res.headers.set("X-Login-Timing-Total", String(Math.round(nowMs() - t0)))
+
+    console.log(
+      JSON.stringify({
+        tag: "api/auth/login",
+        ok: false,
+        error: (e as Error)?.message ?? String(e),
+        rails_login_ms: Math.round(railsMs),
+        total_ms: Math.round(nowMs() - t0),
+        reqId,
+      }),
+    )
     return res
   }
 }

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,147 @@
+// src/app/api/auth/refresh/route.ts
+
+// cspell:ignore dlog derr globy reqId
+import { NextResponse, type NextRequest } from "next/server"
+
+// ===================== DEBUG_START:refresh =====================
+// デバッグON/OFF（.env.local 等で DEBUG_REFRESH=1）
+const DEBUG_ON = process.env.DEBUG_REFRESH === "1"
+
+// JWTらしき文字列を伏せつつログの肥大化を抑止
+function safe(text: string, limit = 800): string {
+  const jwtLike = /eyJ[a-zA-Z0-9_\-.]+/g
+  const redacted = text.replace(jwtLike, "[JWT_REDACTED]")
+  return redacted.length > limit ? redacted.slice(0, limit) + "…(truncated)" : redacted
+}
+
+// any禁止対策：unknownで受けてそのままconsoleへ
+function dlog(...args: unknown[]): void {
+  if (DEBUG_ON) console.log("[BFF:refresh]", ...args)
+}
+function derr(...args: unknown[]): void {
+  if (DEBUG_ON) console.error("[BFF:refresh]", ...args)
+}
+
+// unknownな例外から安全にメッセージ抽出
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === "string") return err
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return String(err)
+  }
+}
+// ===================== DEBUG_END:refresh =======================
+
+function getForwardedCookie(req: NextRequest): string {
+  // クライアント -> BFF の Cookie を Rails へそのまま前方転送
+  return req.headers.get("cookie") ?? ""
+}
+
+function resolveApiBase(): string {
+  return (
+    process.env.API_BASE ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    "http://api:3000" // Docker内の api サービス想定
+  )
+}
+
+// ===================== COOKIE_FWD_START:multi_set_cookie =====================
+/** Undici の getSetCookie() があれば使い、無ければ単一 set-cookie を配列化して返す */
+function getSetCookieList(from: Response): string[] {
+  const h = from.headers as unknown as { getSetCookie?: () => string[] }
+  if (typeof h.getSetCookie === "function") {
+    try {
+      const list = h.getSetCookie()
+      return Array.isArray(list) ? list : []
+    } catch {
+      // フォールバックへ
+    }
+  }
+  const single = from.headers.get("set-cookie")
+  return single ? [single] : []
+}
+
+/** Rails からの複数 Set-Cookie をそのまま前方転送（append） */
+function forwardSetCookies(from: Response, to: NextResponse): void {
+  for (const v of getSetCookieList(from)) {
+    to.headers.append("set-cookie", v)
+  }
+}
+// ===================== COOKIE_FWD_END:multi_set_cookie =====================
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function POST(req: NextRequest) {
+  const t0 = Date.now()
+  const reqId = crypto.randomUUID()
+  const apiBase = resolveApiBase()
+  const url = `${apiBase}/auth/refresh`
+  const fwdCookie = getForwardedCookie(req)
+
+  // ===================== DEBUG_START:refresh =====================
+  dlog("start", {
+    reqId,
+    url,
+    cookiePresent: Boolean(fwdCookie),
+    cookieLen: fwdCookie.length,
+    apiBase,
+  })
+  // ===================== DEBUG_END:refresh =======================
+
+  try {
+    const tFetch0 = Date.now()
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        // Rails へ Cookie をそのまま渡す（超重要）
+        cookie: fwdCookie,
+        "X-Request-ID": reqId, // Railsログ突合
+        "X-BFF": "globy-web",
+      },
+      cache: "no-store",
+    })
+    const railsMs = Date.now() - tFetch0
+
+    const rawText = await res.text()
+    const out = new NextResponse(rawText, { status: res.status })
+
+    // Rails からの Set-Cookie を全件前方転送
+    forwardSetCookies(res, out)
+
+    // 計測・相関ヘッダ
+    const total = Date.now() - t0
+    out.headers.set("Server-Timing", `rails_refresh;dur=${railsMs}, total;dur=${total}`)
+    out.headers.set("X-Refresh-Total-Ms", String(total))
+    out.headers.set("X-Proxy-Request-ID", reqId)
+
+    // ===================== DEBUG_START:refresh =====================
+    dlog("done", {
+      reqId,
+      status: res.status,
+      railsMs,
+      totalMs: total,
+      setCookieCount: getSetCookieList(res).length,
+      respPreview: safe(rawText),
+    })
+    // ===================== DEBUG_END:refresh =======================
+
+    return out
+  } catch (e: unknown) {
+    const total = Date.now() - t0
+
+    // ===================== DEBUG_START:refresh =====================
+    derr("error", { reqId, durMs: total, err: toErrorMessage(e) })
+    // ===================== DEBUG_END:refresh =======================
+
+    const out = NextResponse.json(
+      { ok: false, message: "refresh 呼び出しに失敗しました", reqId },
+      { status: 502 },
+    )
+    out.headers.set("Server-Timing", `refresh_error;dur=${total}`)
+    out.headers.set("X-Proxy-Request-ID", reqId)
+    return out
+  }
+}

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,21 +1,76 @@
 // src/app/api/me/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
-import { resolveApiBase, withBearerFromReq } from '../_auth-helpers'
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
 
-export async function GET(req: NextRequest) {
-  const apiBase = resolveApiBase()
-  const r = await fetch(`${apiBase}/me`, {
-    method: 'GET',
-    headers: withBearerFromReq(req),
-    cache: 'no-store',
+// Rails API のベースURL（環境に合わせて）
+// - Docker: "http://api:3000"
+// - ローカル別ポート: "http://localhost:3001" など
+const API_BASE =
+  process.env.API_BASE_URL ||
+  process.env.INTERNAL_API_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  "http://api:3000"
+
+export const dynamic = "force-dynamic"
+export const runtime = "nodejs"
+
+// Cookie 名の候補（どれかが入っていれば Bearer にも積む）
+const TOKEN_COOKIE_CANDIDATES = [
+  "auth_token",
+  "access_token",
+  "jwt",
+  "token",
+  // 必要なら追加
+] as const
+
+export async function GET() {
+  // Next 15+ 環境では cookies() が Promise の場合があるので await
+  const cookieStore = await cookies()
+
+  // 1) Cookie ヘッダーを自前で組み立て（全ての Cookie を Rails にブリッジ）
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ")
+
+  // 2) Authorization / X-Auth-Token を“候補総当たり”で積む
+  let bearer: string | undefined
+  for (const name of TOKEN_COOKIE_CANDIDATES) {
+    const v = cookieStore.get(name)?.value
+    if (v && v.trim()) {
+      bearer = v
+      break
+    }
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" }
+  if (cookieHeader) headers["Cookie"] = cookieHeader
+  if (bearer) {
+    headers["Authorization"] = `Bearer ${bearer}`
+    headers["X-Auth-Token"] = bearer // 実装差分への保険
+  }
+
+  // 3) Rails の /me を叩く
+  const upstream = await fetch(`${API_BASE}/me`, {
+    method: "GET",
+    headers,
+    cache: "no-store",
   })
 
-  const data = await r.json().catch(() => ({}))
-  if (!r.ok) {
+  // 4) 透過レスポンス
+  if (!upstream.ok) {
+    const text = await upstream.text().catch(() => "")
+    // デバッグ用に最小限のヒントを返す（本番では削ってOK）
     return NextResponse.json(
-      { ok: false, code: data?.code, message: data?.detail || 'Unauthorized' },
-      { status: r.status },
+      {
+        authenticated: false,
+        message: text || "unauthorized",
+        hint: bearer ? "sent bearer + cookies" : "sent cookies only",
+      },
+      { status: 401 },
     )
   }
-  return NextResponse.json({ ok: true, user: data?.user ?? null }, { status: 200 })
+
+  const data = await upstream.json().catch(() => ({}))
+  return NextResponse.json({ authenticated: true, user: data?.user ?? null })
 }

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,0 +1,38 @@
+// src/app/api/session/route.ts
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+
+// Rails API のベースURL（環境に合わせて）
+const API_BASE =
+  process.env.API_BASE_URL ||
+  process.env.INTERNAL_API_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  "http://localhost:3001" // 例: Rails が :3001 で稼働
+
+export const dynamic = "force-dynamic"
+export const runtime = "nodejs"
+
+export async function GET() {
+  // ブラウザの HttpOnly クッキーをサーバ fetch の Cookie ヘッダへ“手動で”転送
+  const cookieHeader = cookies().toString()
+
+  const res = await fetch(`${API_BASE}/me`, {
+    method: "GET",
+    headers: {
+      Cookie: cookieHeader,
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "")
+    return NextResponse.json(
+      { authenticated: false, message: text || "unauthorized" },
+      { status: 401 },
+    )
+  }
+
+  const data = await res.json().catch(() => ({}))
+  return NextResponse.json({ authenticated: true, user: data?.user ?? null })
+}


### PR DESCRIPTION
### 概要
Next.js 側の BFF に `/api/session` および `/api/auth/refresh` のルートを追加し、  
Rails API との Cookie ベース認証連携を安定化しました。  
これにより、ログイン後のセッション確認・トークンリフレッシュが Next.js 経由で正しく動作します。

---

### 変更内容
- `/api/session`
  - Rails `/me` に Cookie を転送し、認証状態を確認
  - `runtime: nodejs`、`dynamic: force-dynamic` を適用
  - `cache: no-store` によりキャッシュを無効化

- `/api/auth/refresh`
  - Rails `/auth/refresh` に Cookie を前方転送
  - 複数の `Set-Cookie` を安全に返却（`getSetCookie()` 対応）
  - `X-Proxy-Request-ID`・`Server-Timing` ヘッダを追加してログ追跡を強化
  - `DEBUG_REFRESH=1` による詳細ログ出力を追加

---

### 技術的ポイント
- BFF層で Cookie を直接操作するため `runtime=nodejs` を採用  
- `fetch` リクエストは `no-store` 指定でステートレス化  
- Rails 側と Next 側で環境変数 (`API_BASE_URL` / `INTERNAL_API_URL`) を共通化  

---

### 動作確認
- [x] `/login` 後に `/api/session` が `authenticated: true` を返す  
- [x] トークン期限切れ時に `/api/auth/refresh` により再発行される  
- [x] `Set-Cookie` が複数同時転送される場合も正しく保持される  
- [x] Rails ログと BFF ログの `Request-ID` が一致する  

---

### 関連Issue
- close #3

---

### 備考
今後 `/api/auth/logout` のBFF対応、および自動リフレッシュ処理のクライアント側実装を予定しています。
